### PR TITLE
Fallback voor de hero image toegevoed

### DIFF
--- a/src/lib/Organism/Carousel.svelte
+++ b/src/lib/Organism/Carousel.svelte
@@ -91,7 +91,7 @@
     <div class="carousel-inner">
       {#each data.wishes as wish}
       <div class="carousel-item">
-        <img class="carousel-image" src={wish.image.url} alt="" decoding="async" width="150" height="150" loading="lazy"/>
+        <img class="carousel-image" src={wish.image.url} alt="" decoding="async" width="150" height="50" loading="lazy"/>
         <div class="carousel-text">
           <h2>
             <!-- Link naar de details van het item -->

--- a/src/lib/Organism/Hero.svelte
+++ b/src/lib/Organism/Hero.svelte
@@ -61,9 +61,10 @@
     }
    /* Hero */
    .hero {
-    background-image: url("https://hallostrandeiland.nl/networks/hallostrandeiland/img/hse_hero-bg.webp");
+    /* background-image: url("https://hallostrandeiland.nl/networks/hallostrandeiland/img/hse_hero-bg.webp");
     background-image: url("https://hallostrandeiland.nl/networks/hallostrandeiland/img/hse_hero-bg.png");
-    background-image: url("https://hallostrandeiland.nl/networks/hallostrandeiland/img/hse_hero-bg.avif");
+    background-image: url("https://hallostrandeiland.nl/networks/hallostrandeiland/img/hse_hero-bg.avif"); */
+    background-image: url("/styles/hero.jpg");
     background-repeat: no-repeat;
     background-size: cover;
     background-position: center;


### PR DESCRIPTION
- [x] Fallback voor de hero toegevoegd voor safari

**Zonder fallback**

<img width="1440" alt="Schermafbeelding 2024-03-28 om 10 20 39" src="https://github.com/zenitba/FDNDStrandeiland/assets/112856019/5f34b254-5992-498f-966d-87cc6915fc01">

**Met fallback**

<img width="1438" alt="Schermafbeelding 2024-03-28 om 10 21 35" src="https://github.com/zenitba/FDNDStrandeiland/assets/112856019/16721da3-e1ba-4341-93bf-a1373530ffe8">


**Toevoeging code**
```css
background-image: url("/styles/hero.jpg");
```